### PR TITLE
Remove line breaks in footer

### DIFF
--- a/content/_global/footer.md
+++ b/content/_global/footer.md
@@ -15,9 +15,9 @@ menu_title = "Useful Links"
 
 #### Club Room Location
 
-Engineering Teaching and Learning Center </br>
-ETLC 2-040M (first right in clubs hallway) </br>
-116 St NW </br>
-Edmonton, AB, Canada </br>
-T6G 2V4 </br>
+Engineering Teaching and Learning Center
+ETLC 2-040M (first right in clubs hallway)
+116 St NW
+Edmonton, AB, Canada
+T6G 2V4
 


### PR DESCRIPTION
This is done since the BlackFriday Markdown processer extension "hardLineBreaks"
was recently enabled, so adding line breaks manually is not necessary anymore.
At least for the footer.