### PR TITLE
Update hugo version to 0.60.1

### DIFF
--- a/archetypes/newsletter.md
+++ b/archetypes/newsletter.md
@@ -5,7 +5,7 @@ categories = []
 
 title = "CompE Club Weekly"
 title_align = "left"
-read_more = true 
+read_more = true
 
 display_date = true
 date = {{ .Date }}
@@ -18,16 +18,17 @@ SUMMARY
   align = "right"
 +++
 SUMMARY
-<br/>   
+<br/>
 
 ### Highlights:
 * Highlight 1
 * Highlight 2
 * Highlight 3
+<br/>
 
 # 1)  ITEM 1
-<!-- 
-Note, not all of these fields (who, what, etc.) are necessary. 
+<!--
+Note, not all of these fields (who, what, etc.) are necessary.
 Remove unnecessary fields. Remove this comment as well.
 -->
 **WHO:** INSERT TEXT HERE
@@ -37,8 +38,8 @@ Remove unnecessary fields. Remove this comment as well.
 <br/>
 
 # 2)  ITEM 2
-<!-- 
-Note, not all of these fields (who, what, etc.) are necessary. 
+<!--
+Note, not all of these fields (who, what, etc.) are necessary.
 Remove unnecessary fields. Remove this comment as well.
 -->
 **WHO:** INSERT TEXT HERE
@@ -48,8 +49,8 @@ Remove unnecessary fields. Remove this comment as well.
 <br/>
 
 # 3)  ITEM 1
-<!-- 
-Note, not all of these fields (who, what, etc.) are necessary. 
+<!--
+Note, not all of these fields (who, what, etc.) are necessary.
 Remove unnecessary fields. Remove this comment as well.
 -->
 **WHO:** INSERT TEXT HERE
@@ -59,4 +60,4 @@ Remove unnecessary fields. Remove this comment as well.
 <br/>
 
 ### Signing Off...
-Thanks for reading this week's edition of the CompE Club Newsletter.  If you have any news or an event you want featured in future editions, contact us at <internal@compeclub.com>!  Be sure to stop by the CompE Club Room to grab a snack and say hi! Prices for most snacks have been slashed, so now is the time to buy. <33 
+Thanks for reading this week's edition of the CompE Club Newsletter.  If you have any news or an event you want featured in future editions, contact us at <internal@compeclub.com>!  Be sure to stop by the CompE Club Room to grab a snack and say hi! Prices for most snacks have been slashed, so now is the time to buy. <33

--- a/config.toml
+++ b/config.toml
@@ -139,5 +139,8 @@ lastmod = ["lastmod", ":git", "date"]
   url = "https://discord.gg/Bvfws6T"
 
 # Markdown Processor Settings
-[blackfriday]
-  extensions = ["hardLineBreak"]
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      hardWraps = true
+      unsafe = true # Needed for inline HTML to render properly (see https://gohugo.io/news/0.60.0-relnotes/)

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo --gc --minify -b $URL"
 
 [context.production.environment]
-HUGO_VERSION = "0.59.1"
+HUGO_VERSION = "0.60.1"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,13 +11,13 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.59.1"
+HUGO_VERSION = "0.60.1"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.59.1"
+HUGO_VERSION = "0.60.1"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
- Fixes site breakage due to changing default markdown
processor from BlackFriday to Goldmark due to change in 
new version of Hugo
- Updates Hugo version in Netlify build environment

Closes #32